### PR TITLE
Betreiber mit Motis-IDs 0-110

### DIFF
--- a/mapping.csv
+++ b/mapping.csv
@@ -102,3 +102,81 @@ L7____,"SBB GmbH",Q1254047
 7872,DB-Nahverkehr,Q18853
 800693,DB Regio AG Baden-Württemberg,Q64504641
 9287,DB Regio Bus Mitte,Q68308888
+0,PKP Intercity,Q249591
+0-1,Keolis Sète,Q664399
+1,ASPO SPA,Q14523772
+1,OEBB Personenverkehr AG Kundenservice,Q83822
+2,Astuce,Q3537964
+2,WESTbahn Management GmbH,Q266280
+3,Akureyri,null
+3,Raaberbahn AG GYSEV Zrt.,Q181697
+4,Wiener Linien GmbH & Co KG,Q668849
+5,Impulsyon,Q2990057
+6,CAT,Q694029
+6,Ville de Luxembourg - Service Autobus,Q2872530
+7,Transvilles,Q664399
+9,Artis,Q664399
+12,Österreichische Postbus AG,Q14912709
+14,Blaguss Reisen GmbH,Q881089
+16,Dr. Richard Verkehrsbetrieb GmbH & Co KG,Q1254031
+18,Partsch Verkehrsbetriebe GmbH,Q2055101
+19,Innsbrucker Verkehrsbetriebe und Stubaitalbahn GmbH,Q1664245
+21,ZuklinBus GmbH,Q125416357
+22,Appenzeller Bahnen (ab),Q247358
+25,Verkehrsbetrieb LIECHTENSTEINmobil,Q172652
+26,Dr. Richard NÖ GmbH & Co KG,Q1254031
+28,Tursib,Q1477885
+29,Stadtbus Dornbirn,Q2326978
+30,Verkehrsbetriebe Burgenland GmbH,Q124418940
+32,SUB,null
+33,BLS AG (bls),Q246824
+35,Graz Linien,Q876786
+36,Steiermarkbahn und Bus GmbH,Q2339142
+37,Baselland Transport,Q353936
+38,Graz Linien,Q876786
+39,Landbus Oberes Rheintal,Q113470526
+40,Österreichische Postbus AG,Q14912709
+41,Aargau Verkehr AG,Q57312492
+45,REGION - cars Région Ain,Q3456850
+46,Landbus Bregenzerwald,Q1801977
+47,Verkehrsbetriebe Brandenburg an der Havel GmbH,Q2516140
+48,Matterhorn Gotthard Bahn (fo),Q666922
+49,Stadtbus Bludenz,Q113485293
+51,Postbus Verkehrsstelle Lech,Q14912709
+53,Transports publics fribourgeois,Q609332
+55,Magyar Allamvasutak,Q168082
+56,Zeleznice Slovenskej republiky,Q393524
+58,Ritmo,Q3433322
+64,Montreux-Oberland Bernois,Q617732
+65,THURBO,Q432448
+66,Stadtwerke Verkehrsbetriebe Wilhelmshaven GmbH,Q1577332
+70,REGION - cars Région Express,Q14021675
+72,Rhätische Bahn,Q177598
+73,REGION - cars Région Savoie,Q27992297
+74,SJ,Q8301325
+76,Vy,Q83825
+78,Sihltal-Zürich-Uetliberg-Bahn,Q664642
+79,Dr. Richard Linien GmbH & Co KG,Q1254031
+80_BOD,FPLAN BOD RAB OMP,null
+80_RVL,FPLAN RBG SWG,null
+80_VHB,FPLAN VHB SBP,null
+81,SWO Mobil GmbH,Q1114682
+81____,Österreichische Bundesbahnen,Q83822
+82,Schweizerische Südostbahn (sob),Q676639
+83,Trenitalia,Q286650
+84,Stadtverkehrsgesellschaft mbH Frankfurt (Oder),Q2328353
+85,Schweizerische Bundesbahnen,Q83835
+86,Zentralbahn,Q190208
+87,Société Nationale des Chemins de fer Français,Q13646
+87_LEX,Société Nationale des Chemins de fer Français,Q13646
+87_SIB,SIBRA,Q3488417
+88,Dopravný podnik Bratislava,Q685601
+91,Sonstige Verkehrsunternehmen,null
+92,Havelbus Verkehrsgesellschaft mbH,Q1591492
+93,Matterhorn Gotthard Bahn (bvz),Q666922
+96,Aargau Verkehr AG,Q57312492
+97,Transports Vallée de Joux-Yverdon-Ste-Croix,Q388731
+99,"IDS JMK (Data from: KORDIS JMK, DPMB)",null
+101,Österreichische Postbus AG - N (Salzburg),Q14912709
+109,Österreichische Postbus AG - W (Tamsweg),Q14912709
+110,Österreichische Postbus AG - W (Zell am See),Q14912709

--- a/missing.csv
+++ b/missing.csv
@@ -755,7 +755,6 @@ motis_id,name
 552,RVHI Regionalverkehr Hildesheim GmbH
 553,SVHI Stadtverkehr Hildesheim GmbH
 566,Busverkehr Oder-Spree GmbH
-6,Ville de Luxembourg - Service Autobus
 6100826,CFR Călători
 615,Verkehrsgemeinschaft Osnabrück
 619,Fluo Grand Est 57

--- a/missing.csv
+++ b/missing.csv
@@ -1,17 +1,9 @@
 motis_id,name
 ,Filibus (Chartres)
-0,PKP Intercity
-0-1,Keolis Sète
-1,ASPO SPA
-1,OEBB Personenverkehr AG Kundenservice
-2,WESTbahn Management GmbH
-3,Raaberbahn AG GYSEV Zrt.
 5,Paznauntaler Verkehrsunternehmen Wilhelm Siegele GmbH
-6,CAT
 7,Burkhard-Reisebüro e.K
 10,VR
 1000,Helsingin seudun liikenne
-101,Österreichische Postbus AG - N (Salzburg)
 10252,Bus Hassis
 10253,Bus NVW (Walz)
 10256,Verkehrsgesellschaft Vorpommern-Rügen
@@ -76,7 +68,6 @@ motis_id,name
 10892,trilex  - Die Länderbahn GmbH DLB
 10894,REGIOBAHN
 10898,Meridian
-109,Österreichische Postbus AG - W (Tamsweg)
 1090,"Hangon liikenne, Friman&Co"
 10904,Mecklenburgische Bäderbahn Molli
 10905,Norddeutsche Eisenbahn Gesellschaft
@@ -95,7 +86,6 @@ motis_id,name
 1097,Vekka liikenne Oy
 10971,Bayerische Zugspitzbahn
 1099,Lehtimäen Liikenne Oy
-110,Österreichische Postbus AG - W (Zell am See)
 11000,Neu KVG
 11002,AKMasten
 11003,HADAG-Z
@@ -147,7 +137,6 @@ motis_id,name
 11981,ARGE HRS Omnibus OHG
 11997,Bruns Reisen GmbH Varel
 11999,Aktiv Bus Flensburg GmbH
-12,Österreichische Postbus AG
 12000,Autokraft Kiel GmbH
 12001,AllerBus
 12009,BREMERHAVEN BUS
@@ -346,7 +335,6 @@ motis_id,name
 13862,Omnibusverkehr Gloss
 13864,Zarth GmbH1
 13886,Kalmer Reisen GmbH
-14,Blaguss Reisen GmbH
 140,Bruns Reisen GmbH Varel
 14071,Ersatzverkehr1
 14076,Brodschelm Linie
@@ -495,7 +483,6 @@ motis_id,name
 153,Vonau Reisedienst GmbH & Co. KG
 154,AllerBus
 157,Wengernalpbahn
-16,Dr. Richard Verkehrsbetrieb GmbH & Co KG
 163,TRENITALIA S.p.A.
 164,Albus
 165,Albus (SVG beauftragt)
@@ -504,13 +491,11 @@ motis_id,name
 171,Société Nationale des Chemins de Fer Luxembourgeois
 1750,Verkehrsbetriebe Bachstein
 176,Stadtwerke Emden GmbH
-18,Partsch Verkehrsbetriebe GmbH
 181,liO Occitanie 81
 183,BLS Schifffahrt AG (brs)
 185,Vierwaldstättersee
 1850,Heidekreis
 1855,Willy Hummert Omnibusverkehr GmbH
-19,Innsbrucker Verkehrsbetriebe und Stubaitalbahn GmbH
 1935,Omnibus-Nahverkehrs-Service
 194,Zürichsee-Schifffahrtsgesellschaft AG (ZSG)
 195,Schweizerische Bodensee-Schifffahrt AG
@@ -524,7 +509,6 @@ motis_id,name
 204,FYNBUS
 206,NT
 2085,Busreisen Andreesen Morten GmbH & Co. KG
-21,ZuklinBus GmbH
 2115,Gebken Reisen GmbH
 2116,Hutfilters Reisedienst GmbH & Co.
 2150,Verkehrsgesellschaft Landkreis Osnabrück
@@ -532,7 +516,6 @@ motis_id,name
 216,Delbus GmbH & Co. KG
 218,BREMERHAVEN BUS
 219,Arosa Bergbahnen
-22,Appenzeller Bahnen (ab)
 22002,Intersul
 22003,Internorte
 22004,Transcarioca
@@ -555,7 +538,6 @@ motis_id,name
 243,Aachener Straßenbahn und Energieversorgungs-AG
 246,Verkehrsgesellschaft Teltow-Fläming mbH
 2480,Hülsmann Reisen
-25,Verkehrsbetrieb LIECHTENSTEINmobil
 2505,Regionalverkehre Start Deutschland (Niedersachsen-Mitte)
 251,Regionale Verkehrsgesellschaft Dahme-Spreewald mbH
 252,Sörmlandstrafiken
@@ -566,7 +548,6 @@ motis_id,name
 2575,Kalmer Reisen GmbH
 258,WestVerkehr GmbH
 259,Verkehrsgemeinschaft Grafschaft Bentheim
-26,Dr. Richard NÖ GmbH & Co KG
 2606,Weihrauch Uhlendorff GmbH
 2607,Regiobus Uhlendorff GmbH & Co. KG
 261,Hallandstrafiken
@@ -582,15 +563,11 @@ motis_id,name
 276,Skånetrafiken
 277,Flygbussarna
 279,Västtrafik
-28,Tursib
 281,Midttrafik
 286,CeBus GmbH & Co. KG
 287,Arlanda Express
-29,Stadtbus Dornbirn
 2910,NRC Group Finland Oy
 299,Zermatt Bergbahnen AG
-3,Akureyri
-30,Verkehrsbetriebe Burgenland GmbH
 300,Öresundståg
 3025,Reisebüro Schmidt
 3030,MEW Mobilitätszentrale Elbe-Weser
@@ -600,51 +577,35 @@ motis_id,name
 315,Vy Tåg
 318,DSB S-tog
 319,Metroselskabet
-32,SUB
 323,Salzburg AG (OBus)
 325,Tåg i Bergslagen
 326,Salzburg AG (Salzburger Lokalbahn)
 327,Vy Bus4You
 327000,TreNord
-33,BLS AG (bls)
 336,Sydtrafik
 3385,Fenniarail Oy
 341,Verkehrsmanagement Elbe-Elster GmbH
 346,Verkehrsgesellschaft Oberspreewald-Lausitz mbH
-35,Graz Linien
-36,Steiermarkbahn und Bus GmbH
 360,Bodensee-Schiffsbetriebe GmbH
 361,MasExpressen
 365,Härjedalingen
-37,Baselland Transport
-38,Graz Linien
 380,Snälltåget
 381,Gerdes Reisen
 3849,Verkehrsbetriebe Zürich INFO+
-39,Landbus Oberes Rheintal
 391,Nikkaluoktaexpressen
 3955,Trasporti Pubblici Luganesi SA
-4,Wiener Linien GmbH & Co KG
-40,Österreichische Postbus AG
 401,Skånetrafiken
-41,Aargau Verkehr AG
 410,TRANSAL
 42,Forbus
 43,Oberger
 44,Tyroltours GmbH
-45,REGION - cars Région Ain
 450,Fluo Grand Est 67
 456,Odense Letbane
-46,Landbus Bregenzerwald
-47,Verkehrsbetriebe Brandenburg an der Havel GmbH
 471,GoCollective
 476,Fritz Behrendt OHG
-48,Matterhorn Gotthard Bahn (fo)
 480,Glaser
 486,Schöneicher Rüdersdorfer Straßenbahn GmbH
 487,Strausberger Eisenbahn GmbH
-49,Stadtbus Bludenz
-5,Impulsyon
 50,First Greater Glasgow
 50-1-1-SBLB,Stagecoach Bluebird
 50-1-1-SCGL,Stagecoach West
@@ -778,7 +739,6 @@ motis_id,name
 50-2-XR,Elizabeth line
 50-2-ZZ,Agency
 500,CTM Spa
-51,Postbus Verkehrsstelle Lech
 51-49-GLE,Goldline Express
 51-50-WIRISHI,Translink Northern Ireland Rail
 5111,SNCF Voyageurs SA
@@ -787,18 +747,14 @@ motis_id,name
 52,Reisebüro Breuss
 5235,SNCF Voyageurs EA
 5270,SNCF Voyageurs LO
-53,Transports publics fribourgeois
 54,ARGE Tiroler Zugspitzbahn Tyroltours
 546,Kraftverkehrsgesellschaft mbH Braunschweig
 547,Peiner Verkehrsgesellschaft mbH
 549,Verkehrsgesellschaft Landkreis Gifhorn mbH
-55,Magyar Allamvasutak
 550,Wolfsburger Verkehrs-GmbH
 552,RVHI Regionalverkehr Hildesheim GmbH
 553,SVHI Stadtverkehr Hildesheim GmbH
-56,Zeleznice Slovenskej republiky
 566,Busverkehr Oder-Spree GmbH
-58,Ritmo
 6,Ville de Luxembourg - Service Autobus
 6100826,CFR Călători
 615,Verkehrsgemeinschaft Osnabrück
@@ -807,20 +763,14 @@ motis_id,name
 629,Haparanda lokaltrafik
 631,Krautgartner-Bus
 637,Boden Stadstrafik
-64,Montreux-Oberland Bernois
-65,THURBO
-66,Stadtwerke Verkehrsbetriebe Wilhelmshaven GmbH
 662,Dr. Richard -Standort Oberösterreich
 6750,OSL / Koiviston Auto Oulu Oy
 685,Lüchow-Schmarsauer Eisenbahn
 690,Nordhessischer Verkehrsverbund
-7,Transvilles
-70,REGION - cars Région Express
 7031,Aroser Verkehrsbetriebe
 706,Sabinchen Touristik GmbH
 708,Elektrobus Zermatt
 716,Ortsbus St. Moritz
-72,Rhätische Bahn
 720,Bittner/Emsland-Mitte
 722,Stern & Hafferl Kraftfahrlinien GmbH
 723,Aargau Verkehr AG
@@ -828,11 +778,9 @@ motis_id,name
 7231,SBB Infrastruktur AG Bahnersatz
 7250,Rhätische Bahn Ersatzverkehr
 726,ORP Ostprignitz-Ruppiner Personennahverkehrsgesellschaft mbH
-73,REGION - cars Région Savoie
 731,ODEG Ostdeutsche Eisenbahn GmbH
 736,Autolinea Mendrisiense SA
 737,Servizio d'automobili
-74,SJ
 744,Wels Linien GmbH
 7493,Rurseeschifffahrt
 7496,Schienenersatzverkehr
@@ -862,7 +810,6 @@ motis_id,name
 7589,Landkreis Cham
 7593,Calw VPC
 7599,Stadtwerke Biberach
-76,Vy
 760,Astuce
 7600,Klemens Diesch
 7601,Diesch GmbH
@@ -927,7 +874,6 @@ motis_id,name
 7796,RLG AST
 7797,Westfalen Bus
 7798,RVM Kreis Steinfurt
-78,Sihltal-Zürich-Uetliberg-Bahn
 780,Usedomer Bäder Bahn Bus
 7800,Weilke Kreis ST
 7803,RVM Kreis Borken
@@ -969,7 +915,6 @@ motis_id,name
 7888,OBB-Beck
 7889,S.Wilhelm-OBB
 7891,Schmidt-Reisen
-79,Dr. Richard Linien GmbH & Co KG
 7904,Regionalbusse (privat)
 7906,Anruf-Sammel-Taxi
 7909,RNV LU-MA (Strab)
@@ -1015,9 +960,6 @@ motis_id,name
 7988,Röhler
 7989,Niederrheinwerke Viersen mobil GmbH
 7992,NE-Zug (VVS)
-80_BOD,FPLAN BOD RAB OMP
-80_RVL,FPLAN RBG SWG
-80_VHB,FPLAN VHB SBP
 8000,Ruftaxi entlang Linie
 8001,Ruftaxi nicht entlang Linie
 8005,Museumsstraßenbahn (SHB)
@@ -1059,8 +1001,6 @@ motis_id,name
 8085,RBA Neu Ulm
 8086,Schwabenbus Dillingen
 8087,Landkreis Rottal
-81,SWO Mobil GmbH
-81____,Österreichische Bundesbahnen
 810,WestfalenBahn
 8103,RVS
 8106,Regensburger Verkehrsbetrieb
@@ -1104,7 +1044,6 @@ motis_id,name
 8196,VGM-Busverkehr
 8197,RBO-Busverkehr
 8198,VGH Busverkehr
-82,Schweizerische Südostbahn (sob)
 820,Verkehrsbetriebe Luzern AG
 8203,Bergbahn
 8205,Fähre
@@ -1114,17 +1053,14 @@ motis_id,name
 822,Busbetrieb BOB
 823,Basler Verkehrsbetriebe
 827,Städtische Verkehrsbetriebe Bern
-83,Trenitalia
 832,Autobetrieb Weesen-Amden
 834,Service d'automobiles TPF
 838,Flixbus
 839,Zugerland Verkehrsbetriebe
-84,Stadtverkehrsgesellschaft mbH Frankfurt (Oder)
 841,Auto AG Schwyz
 843,bus
 846,regiobus Potsdam Mittelmark GmbH
 849,Verkehrsbetriebe Zürich
-85,Schweizerische Bundesbahnen
 850,Autobusbetrieb RBS
 851,Automobildienst Matterhorn Gotthard Bahn (fo auto)
 8571,Oberhavel Verkehrsgesellschaft mbH
@@ -1139,7 +1075,6 @@ motis_id,name
 8595,Stadtverkehrsgesellschaft mbH Frankfurt (Oder)
 8596,Regionale Verkehrsgesellschaft Dahme-Spreewald mbH
 8599,Strausberger Eisenbahn GmbH
-86,Zentralbahn
 8601,Verkehrsmanagement Elbe-Elster GmbH
 8603,ORP Ostprignitz-Ruppiner Personennahverkehrsgesellschaft mbH
 8606,Verkehrsbetrieb Potsdam GmbH
@@ -1171,9 +1106,6 @@ motis_id,name
 8689,VGO Gießen
 8694,ALV Marburg
 8696,Stadtwerke Bad Nauheim
-87,Société Nationale des Chemins de fer Français
-87_LEX,Société Nationale des Chemins de fer Français
-87_SIB,SIBRA
 870,Automobildienste Aare Seeland mobil
 8709,Medenbach Traffic GmbH
 8719,ALV Oberhessen
@@ -1198,7 +1130,6 @@ motis_id,name
 8760,Stroh Busverkehr GmbH
 8766,VGO Friedberg
 8767,Stadtverkehr Maintal
-88,Dopravný podnik Bratislava
 881,Transports Publics Genevois
 882,Stadtbus Winterthur
 885,Verkehrsbetriebe der Stadt St.Gallen
@@ -1228,12 +1159,9 @@ motis_id,name
 895,Transports Vallée de Joux-Yverdon-Ste-Croix
 896,Regiobus Gossau SG
 8965,Bayerische Oberlandbahn
-9,Artis
 9020,"Železničná spoločnosť Slovensko, a.s."
-91,Sonstige Verkehrsunternehmen
 9141,KVG Bus
 9142,KVG Tram
-92,Havelbus Verkehrsgesellschaft mbH
 9222,EW Bus GmbH
 9225,RhönEnergie Bus GmbH (NVV)
 9226,Frölich Bus GmbH
@@ -1249,7 +1177,6 @@ motis_id,name
 9276,HLB Bus GmbH
 9281,mobus Märkisch-Oderland Bus GmbH
 9282,ARGE prignitzbus
-93,Matterhorn Gotthard Bahn (bvz)
 9316,Padersprinter
 9319,nph-Linienbündel 01
 9320,nph-Linienbündel 02
@@ -1278,14 +1205,11 @@ motis_id,name
 9571,Regionalbuslinien
 9572,RVV-VLC für EFA
 9575,Bus8
-96,Aargau Verkehr AG
 9616,Fritz Behrendt OHG2
 9620,regiobus Potsdam Mittelmark GmbH
 9641,ESE Verkehrsgesellschaft mbH
 969,eurobahn
-97,Transports Vallée de Joux-Yverdon-Ste-Croix
 976,Niederbarnimer Eisenbahngesellschaft GmbH
-99,"IDS JMK (Data from: KORDIS JMK, DPMB)"
 9999,GRK Rail Oy
 ALEOP_72,Aléop en Sarthe
 ALEOP:Operator:ALEOP_44,Aléop en Loire-Atlantique

--- a/operators.csv
+++ b/operators.csv
@@ -1051,3 +1051,53 @@ Q2541126,Waldbahn
 Q19296997,National Express
 Q705684,S-Bahn Rhein-Main
 Q81001,S-Bahn Stuttgart
+Q249591,Polskie Koleje Państwowe (PKP)
+Q664399,Keolis
+Q14523772,ASPO Olbia
+Q83822,Österreichische Bundesbahnen
+Q3537964,Astuce
+Q266280,WESTbahn
+Q181697,Raaberbahn AG
+Q668849,Wiener Linien
+Q2990057,Impulsyon
+Q694029,City Airport Train (CAT)
+Q2872530,Autobus de la Ville de Luxembourg
+Q14912709,Österreichische Postbus AG
+Q881089,Blaguss
+Q1254031,Dr. Richard
+Q2055101,Partsch
+Q1664245,Innsbrucker Verkehrsbetriebe
+Q125416457,ZuklinBus
+Q247358,Appenzeller Bahnen
+Q172652,Verkehrsbetrieb LIECHTENSTEINmobil
+Q1477885,Tursib
+Q2326978,Stadtbus Dornbirn
+Q124418940,Verkehrsbetriebe Burgenland
+Q246824,BLS AG
+Q876786,Graz Linien
+Q2339142,Steiermarkbahn
+Q353936,Baselland Transport
+Q113470526,Landbus Oberes Rheintal
+Q57312492,Aargau Verkehr
+Q3456850,Cars Région Ain
+Q27992297,Cars Région Savoie
+Q14021675,Cars Région
+Q1801977,Landbus Bregenzerwald
+Q666922,Matterhorn-Gotthard-Bahn
+Q113485293,Stadtbus Bludenz
+Q609332,Transports publics fribourgeois
+Q168082,Magyar Államvasutak (MÁV)
+Q393524,Zeleznice Slovenskej republiky
+Q3433322,Ritmo
+Q617732,Montreux Berner Oberland Bahn
+Q432448,THURBO
+Q177598,Rhätische Bahn
+Q8301325,SJ
+Q83825,Norges Statsbaner
+Q664642,Sihltal Zürich Uerliberg Bahn
+Q676639,Schweizerische Südostbahn (SOB)
+Q286650,Trenitalia
+Q190208,Zentralbahn
+Q13646,Société nationale des chemins de fer français (SNCF)
+Q3488417,SIBRA
+Q388731,TRAVYS

--- a/operators.csv
+++ b/operators.csv
@@ -1067,7 +1067,7 @@ Q881089,Blaguss
 Q1254031,Dr. Richard
 Q2055101,Partsch
 Q1664245,Innsbrucker Verkehrsbetriebe
-Q125416457,ZuklinBus
+Q125416357,ZuklinBus
 Q247358,Appenzeller Bahnen
 Q172652,Verkehrsbetrieb LIECHTENSTEINmobil
 Q1477885,Tursib
@@ -1101,3 +1101,4 @@ Q190208,Zentralbahn
 Q13646,Société nationale des chemins de fer français (SNCF)
 Q3488417,SIBRA
 Q388731,TRAVYS
+Q685601,Dopravný podnik Bratislava


### PR DESCRIPTION
Ausgenommen sind einzelne Betreiber ohne eine eigene ID bei Wikidata und britische Betreiber mit Motis-ID im 50er Bereich.