### PR TITLE
Remapping Arverio DE -> Arverio BW & Umbenennung SBS zu DBRS

### DIFF
--- a/mapping.csv
+++ b/mapping.csv
@@ -31,7 +31,7 @@ motis_id,motis_name,wikidata_id
 351,"SBB GmbH (Grenzverkehr)",Q1254047
 10822,"SBB GmbH",Q1254047
 L7____,"SBB GmbH",Q1254047
-12827,"Go-Ahead Verkehrsgesellschaft Deutschland mbH",Q30644989
+12827,"Go-Ahead Verkehrsgesellschaft Deutschland mbH",Q64212458
 13631,"Go-Ahead Baden-Württemberg GmbH",Q64212458
 13786,"Go-Ahead Bayern GmbH",Q64212479
 7996,Privatunternehmer-Bus (VVS),null

--- a/operators.csv
+++ b/operators.csv
@@ -883,7 +883,7 @@ Q1710037,Süddeutsche Eisenbahn-Gesellschaft
 Q1660947,Südostbayernbahn
 Q2381690,SüdwestBus
 Q2208728,SWB Bus und Bahn
-Q27649273,SWEG Bahn Stuttgart
+Q27649273,DB Regio Stuttgart
 Q124608127,SWEG Schienenwege GmbH
 Q2381732,SWEG Südwestdeutsche Landesverkehrs-GmbH
 Q2208780,SWK MOBIL


### PR DESCRIPTION
fixes #18

Außerdem SWEG Bahn Stuttgart zu DB Regio Stuttgart umbenannt (weiß nicht, inwiefern das klappt)